### PR TITLE
fixing pause/resume

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -108,7 +108,7 @@
   DOM.on($el.togglePlay, 'click', () => {
     tp.config.play = !tp.config.play;
     $el.togglePlay.innerText = tp.config.play ? 'Stop' : 'Start';
-    tp.draw();
+    //tp.draw();
   });
 
   const updateStateValues = () => {


### PR DESCRIPTION
You kept starting a new render loop by invoking `tp.draw()` here for each time resuming the animation, which resulted in increasing speed and flaky FPS.

You don't need to invoke `tp.draw()` here at all, since the loop gets started once and for all.